### PR TITLE
Handle error on fetch/parse of did

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,10 @@ const resolveDid = async (did: string) => {
     did.startsWith("did:web") ?
       `https://${did.split(":")[2]}/.well-known/did.json`
     : "https://plc.directory/" + did,
-  );
+  ).catch((error: unknown) => {
+    console.warn("Failed to resolve DID", { error, did });
+  });
+  if (!res) return "";
 
   return res
     .json()
@@ -75,7 +78,10 @@ const resolveDid = async (did: string) => {
         }
       }
     })
-    .catch(() => "");
+    .catch((error: unknown) => {
+      console.warn("Failed to parse DID", { error, did });
+      return "";
+    });
 };
 
 const Login: Component = () => {


### PR DESCRIPTION
There's a DID that seems to be no longer valid in my follows and it was crashing the app.

This fix just adds a `.catch` after a `fetch` and it seems to work.

Before:

![Progress: 110/111](https://github.com/user-attachments/assets/703662b8-77a4-4f10-9b03-19a6caf2eeb0)

After:

![image](https://github.com/user-attachments/assets/56a5f4ae-19e5-4262-9731-32190dc17403)

Added error log:

![a console warn in action](https://github.com/user-attachments/assets/be6fece4-4228-43ff-89f5-bc2ce15c5bb2)

Confirm that it works:

![image](https://github.com/user-attachments/assets/64c3bbaf-3b45-4d1f-8473-7d3bc9545b0c)

```json
{
	"commit": {
		"cid": "bafyreid7u2pzmrqmakfaswbcd5gxpxt3mzkv3udv6a3uzfd7efhsn5bfri",
		"rev": "3lildx7gid523"
	},
	"results": [{ "$type": "com.atproto.repo.applyWrites#deleteResult" }]
}
```