### PR TITLE
Fix selected items counter to respect visibility toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -417,7 +417,7 @@ const Follows: Component = () => {
   const [selectedCount, setSelectedCount] = createSignal(0);
 
   createEffect(() => {
-    setSelectedCount(followRecords.filter((record) => record.toDelete).length);
+    setSelectedCount(followRecords.filter((record) => record.toDelete && record.visible).length);
   });
 
   function editRecords(


### PR DESCRIPTION
### Problem
The current implementation of the selected items counter displays the total number of items marked for deletion, regardless of whether they are currently visible in the UI. This creates a confusing user experience where the "Selected: X/Y" display shows a count that doesn't match what users can actually see on screen.

For example, if a user:

Has 5 deleted accounts (all selected)
Has 3 blocked accounts (all selected)
Toggles **OFF** the "Deleted" category

The counter would still show "Selected: 8/8" even though only 3 items are visible. This disconnect between the visual state and the reported numbers undermines user confidence and creates confusion about what will actually be affected by their actions.

### Solution
Modified the createEffect function in the AccountList component to include a visibility check when counting selected items:

Before:
`setSelectedCount(currentRecords().filter((record) => record.toDelete).length);`

After:
`setSelectedCount(currentRecords().filter((record) => record.toDelete && record.visible).length);`

### Impact
This change ensures that:

- The selected count accurately reflects what users see on screen
- Toggle switches provide consistent behavior across all UI elements
- Users have clear, accurate information about their selections
- The principle of "what you see is what you get" is maintained

### Testing
Tested the following scenarios:

✅ Toggling categories on/off updates the count correctly
✅ Selecting/deselecting items within visible categories works as expected
✅ No regression in the actual deletion/unfollowing functionality