### PR TITLE
Fix: Auto-deselect hidden items to prevent unintended deletions (follow-up to #9)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -460,13 +460,13 @@ const Follows: Component = () => {
                     type="checkbox"
                     class="peer sr-only"
                     checked
-                    onChange={(e) =>
-                      editRecords(
-                        option.status,
-                        "visible",
-                        e.currentTarget.checked,
-                      )
-                    }
+                    onChange={(e) => {
+                      const isChecked = e.currentTarget.checked;
+                      editRecords(option.status, "visible", isChecked);
+                      if (!isChecked) {
+                        editRecords(option.status, "toDelete", false);
+                      }
+                    }}
                   />
                   <span class="peer relative h-5 w-9 rounded-full bg-gray-200 after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-blue-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rtl:peer-checked:after:-translate-x-full dark:border-gray-600 dark:bg-gray-700 dark:peer-focus:ring-blue-800"></span>
                   <span class="ms-3 select-none">{option.label}</span>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -417,7 +417,7 @@ const Follows: Component = () => {
   const [selectedCount, setSelectedCount] = createSignal(0);
 
   createEffect(() => {
-    setSelectedCount(followRecords.filter((record) => record.toDelete).length);
+    setSelectedCount(followRecords.filter((record) => record.toDelete && record.visible).length);
   });
 
   function editRecords(


### PR DESCRIPTION
According to #9 this is a follow-up PR

### Problem

While PR #9  correctly fixed the display counter to show only visible selected items, a deeper UX issue remained: users could still unintentionally delete accounts they couldn't see.

User Journey that demonstrates the problem:

User has 10 deleted accounts and 5 blocked accounts
User selects all deleted accounts (10 items)
User also accidentally selects 2 blocked accounts
User decides they want to focus only on deleted accounts, so they toggle OFF the "Blocked" category
User sees only deleted accounts and clicks "Confirm"
Unexpected result: Not only the 10 visible deleted accounts are removed, but also the 2 invisible blocked accounts

That violates WYSIWYG.

### Solution

Enhanced the toggle behavior to automatically clear selections when a category is hidden. This is implemented by modifying the onChange handler for category toggle switches to include selection cleanup:

Before:
`onChange={(e) =>
  editRecords(
    option.status,
    "visible",
    e.currentTarget.checked,
  )
}`

After:
`onChange={(e) => {
  const isChecked = e.currentTarget.checked;
  editRecords(option.status, "visible", isChecked);
  if (!isChecked) {
    editRecords(option.status, "toDelete", false);
  }
}}`

This change implements the principle that "invisible items cannot be selected." When users hide a category, they're expressing that these items are temporarily not relevant to their current task. It would be counterintuitive for hidden items to still affect their actions.

### Impact

- Prevents accidental deletions of accounts in hidden categories
- Improves user confidence by ensuring all actions are predictable and visible
- Maintains consistency with the mental model that hidden = not active
- Complements PR #9 by solving the underlying behavioral issue, not just the display issue

### Testing

✅ Hide category with selected items → selections are automatically cleared
✅ Show category again → starts with clean slate (no remembered selections)
✅ Toggle categories multiple times → no phantom selections remain
✅ Mix of visible and hidden categories → only visible selections count and are actionable
✅ Actual deletion process → only visible, selected items are affected
✅ No regression in core functionality

Hopefully this won't impact other functionalities or led to misunderstandings.